### PR TITLE
Fix README code block and add example env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+POSTGRES_USER=devuser
+POSTGRES_PASSWORD=devpass
+POSTGRES_DB=devdb
+# Connection string used by the Flask app
+DATABASE_URL=postgresql://devuser:devpass@db:5432/devdb

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Setting up a local dev environment with multiple services can be error-prone and
 
 ## 🚀 Quick Start
 
-1. **Clone this repo**  
+1. **Clone this repo**
    ```bash
    git clone https://github.com/Shaugato/dockerized-dev-env-template.git
-
+   ```
 
 2. **Copy `.env.example` to `.env`**
 


### PR DESCRIPTION
## Summary
- provide example env vars in `.env.example`
- close git clone code block in README

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844cf0e50c48321a0df23ae483d3eeb