### PR TITLE
Add test instructions in README and pin Werkzeug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -110,3 +110,25 @@ services:
     networks:
       - devnet
 ```
+
+---
+
+## ✅ Running Tests
+
+This project includes a small [Pytest](https://docs.pytest.org/) suite that
+validates the Flask endpoints and the SQL migrations. The tests run against a
+temporary SQLite database so Docker isn't required.
+
+1. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   (Pytest ships with the dev container and doesn't need a separate install.)
+
+2. **Execute the tests**
+   ```bash
+   pytest -q
+   ```
+
+The suite loads `db/init.sql`, sets up a temporary database, and then issues
+HTTP requests to the Flask app using its test client. All tests should pass.

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 import os
 import psycopg2
+import sqlite3
 from flask import Flask, jsonify
 
 app = Flask(__name__)
@@ -10,8 +11,16 @@ app = Flask(__name__)
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 def get_db_connection():
-    conn = psycopg2.connect(DATABASE_URL)
-    return conn
+    """Return a database connection.
+
+    Supports PostgreSQL via psycopg2 and SQLite for local testing when
+    ``DATABASE_URL`` starts with ``sqlite://``.
+    """
+    url = os.getenv("DATABASE_URL", DATABASE_URL)
+    if url and url.startswith("sqlite://"):
+        path = url[len("sqlite://") :]
+        return sqlite3.connect(path)
+    return psycopg2.connect(url)
 
 @app.route("/")
 def index():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.2.5
+Werkzeug<3.0
 psycopg2-binary==2.9.7

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,56 @@
+"""Integration tests using the real Flask package and a temporary SQLite DB."""
+
+import os
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+@pytest.fixture(scope="module")
+def app_module(tmp_path_factory):
+    db_file = tmp_path_factory.mktemp('db') / 'test.db'
+    os.environ['DATABASE_URL'] = f'sqlite:///{db_file}'
+    import app.main as main
+    importlib.reload(main)
+
+    # apply database schema
+    conn = main.get_db_connection()
+    sql = Path('db/init.sql').read_text().replace('SERIAL', 'INTEGER')
+    conn.executescript(sql)
+    conn.close()
+    yield main
+
+
+@pytest.fixture
+def client(app_module):
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def test_index(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert resp.get_json() == {"message": "Welcome to Dockerized Dev Env Template!"}
+
+
+def test_list_users(client):
+    resp = client.get('/users')
+    assert resp.status_code == 200
+    assert resp.get_json() == [
+        {"id": 1, "name": 'Alice Example', 'email': 'alice@example.com'},
+        {"id": 2, "name": 'Bob Example', 'email': 'bob@example.com'}
+    ]
+
+
+def test_health_ok(client):
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "OK"}
+
+
+def test_health_fail(client, app_module):
+    with patch.object(app_module, 'get_db_connection', side_effect=Exception('db down')):
+        resp = client.get('/health')
+    assert resp.status_code == 500
+    assert resp.get_json() == {"status": "FAIL"}

--- a/tests/test_db_init.py
+++ b/tests/test_db_init.py
@@ -1,0 +1,17 @@
+import re
+from pathlib import Path
+
+INIT_SQL = Path('db/init.sql').read_text()
+
+def test_users_table_created():
+    # Check that users table is created with id, name and email columns
+    pattern = re.compile(r"CREATE TABLE IF NOT EXISTS\s+users", re.IGNORECASE)
+    assert pattern.search(INIT_SQL)
+    assert 'id SERIAL PRIMARY KEY' in INIT_SQL
+    assert 'name VARCHAR(100) NOT NULL' in INIT_SQL
+    assert 'email VARCHAR(100) NOT NULL UNIQUE' in INIT_SQL
+
+def test_seed_users():
+    # Ensure seed data contains at least Alice and Bob
+    assert "('Alice Example', 'alice@example.com')" in INIT_SQL
+    assert "('Bob Example', 'bob@example.com')" in INIT_SQL


### PR DESCRIPTION
## Summary
- document running pytest against the SQLite setup
- pin Werkzeug < 3.0 for Flask 2.2 compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d39810b4832191f34b0dc0ec4589