### PR TITLE
Add EFK logging stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,53 +21,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # (Skip Docker Hub login entirely if you’re not pushing images)
-      # - name: Log in to Docker Hub (optional)
-      #   if: ${{ and(secrets.DOCKERHUB_USERNAME, secrets.DOCKERHUB_TOKEN) }}
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build Flask app image
+      - name: Build and start services
         run: |
-          docker build \
-            --file Dockerfile \
-            --tag dev-app:ci \
-            .
+          docker-compose up -d --build
 
-      - name: Run container health check
+      - name: Wait for services
         run: |
-          # 1. Start a temporary PostgreSQL container
-          docker run -d --name tmp-db \
-            -e POSTGRES_USER=testuser \
-            -e POSTGRES_PASSWORD=testpass \
-            -e POSTGRES_DB=testdb \
-            postgres:13-alpine
-
-          # 2. Wait until Postgres is ready
-          until docker exec tmp-db pg_isready; do
-            sleep 1
+          for i in {1..60}; do
+            if curl -s http://localhost:9200 >/dev/null && curl -s http://localhost/health >/dev/null; then
+              echo "Services are up" && break
+            fi
+            echo "Waiting for services..."
+            sleep 5
           done
 
-          # 3. Run the Flask container with port binding so runner can access it
-          docker run -d --name tmp-app -p 5000:5000 --link tmp-db:db \
-            -e DATABASE_URL="postgresql://testuser:testpass@db:5432/testdb" \
-            dev-app:ci
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
 
-          # 4. Give Flask a moment to start
-          sleep 5
+      - name: Run tests
+        run: pytest -q
 
-          # 5. From the runner (NOT inside the container), curl the health endpoint
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/health)
-          if [ "$HTTP_CODE" -ne 200 ]; then
-            echo "Health check failed with status $HTTP_CODE"
-            exit 1
-          fi
-
-          echo "Health check passed."
-
-      - name: Clean up containers
+      - name: Tear down
         if: always()
-        run: |
-          docker rm -f tmp-app tmp-db || true
+        run: docker-compose down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build and start services
         run: |
-          docker-compose up -d --build
+          docker compose up -d --build
 
       - name: Wait for services
         run: |
@@ -43,4 +43,4 @@ jobs:
 
       - name: Tear down
         if: always()
-        run: docker-compose down -v
+        run: docker compose down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Create .env file
+        run: cp .env.example .env
+
       - name: Build and start services
         run: |
           docker compose up -d --build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
             echo "Waiting for services..."
             sleep 5
           done
+          if ! curl -s http://localhost:9200 >/dev/null || ! curl -s http://localhost/health >/dev/null; then
+            echo "Services failed to start"
+            docker compose logs
+            exit 1
+          fi
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt
@@ -46,4 +51,5 @@ jobs:
 
       - name: Tear down
         if: always()
-        run: docker compose down -v
+        run: |
+          docker compose down -v --remove-orphans --timeout 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.py[cod]
+logs/

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ validates the Flask endpoints and the SQL migrations.
    ```bash
    pip install -r requirements.txt
    ```
-   (Pytest ships with the dev container and doesn't need a separate install.)
+   (This installs Pytest along with the app requirements.)
 
 2. **Execute the tests**
    ```bash

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Setting up a local dev environment with multiple services can be error-prone and
 
 - A **Flask** web application (Python 3.9)  
 - A **PostgreSQL** database (v13) with initial seed SQL  
-- **Adminer** (lightweight DB GUI) for quick table browsing  
-- An **Nginx** reverse proxy (routes `/` → Flask, `/adminer` → Adminer)  
-- A single `docker-compose.yml` to orchestrate everything  
+- **Adminer** (lightweight DB GUI) for quick table browsing
+- An **Nginx** reverse proxy (routes `/` → Flask, `/adminer` → Adminer)
+- An **EFK** stack (Elasticsearch + Fluentd + Kibana) that centralizes all container logs
+- A single `docker-compose.yml` to orchestrate everything
 - A **GitHub Actions** workflow that builds and tests the Docker images  
 - A clean `.env.example` for easy environment configuration  
 
@@ -51,6 +52,7 @@ Setting up a local dev environment with multiple services can be error-prone and
    * **Flask app** → [http://localhost](http://localhost)
    * **Adminer GUI** → [http://localhost/adminer](http://localhost/adminer)
    * (Nginx listens on port 80)
+   * Kibana UI → [http://localhost:5601](http://localhost:5601) (all container logs)
 
 4. **Verify**
 
@@ -86,6 +88,11 @@ Setting up a local dev environment with multiple services can be error-prone and
   * Server: `db`
   * Username/Password: from `.env`
   * Database: `devdb`
+
+* **Kibana (Logs UI)**
+
+  * URL: [http://localhost:5601](http://localhost:5601)
+  * Elasticsearch host: `elasticsearch:9200`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Setting up a local dev environment with multiple services can be error-prone and
 3. **Build & spin up containers**
 
    ```bash
-   docker-compose up --build
+   docker compose up --build
    ```
 
    * **Flask app** → [http://localhost](http://localhost)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       driver: "fluentd"
       options:
         fluentd-address: localhost:24224
-        fluentd-async-connect: "true"
         tag: docker.dev-db
     env_file:
       - .env
@@ -29,7 +28,6 @@ services:
       driver: "fluentd"
       options:
         fluentd-address: localhost:24224
-        fluentd-async-connect: "true"
         tag: docker.dev-adminer
     ports:
       - "8080:8080"
@@ -48,7 +46,6 @@ services:
       driver: "fluentd"
       options:
         fluentd-address: localhost:24224
-        fluentd-async-connect: "true"
         tag: docker.dev-app
     env_file:
       - .env
@@ -68,7 +65,6 @@ services:
       driver: "fluentd"
       options:
         fluentd-address: localhost:24224
-        fluentd-async-connect: "true"
         tag: docker.dev-nginx
     ports:
       - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,17 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: localhost:24224
+        fluentd-address: fluentd:24224
         tag: docker.dev-db
-        fluentd-async-connect: "true"
     env_file:
       - .env
     volumes:
       - db-data:/var/lib/postgresql/data
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
-    networks:
-      - devnet
+      networks:
+        - devnet
+      depends_on:
+        - fluentd
 
   adminer:
     image: adminer:latest
@@ -26,13 +27,14 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: localhost:24224
+        fluentd-address: fluentd:24224
         tag: docker.dev-adminer
-        fluentd-async-connect: "true"
     ports:
       - "8080:8080"
     networks:
       - devnet
+    depends_on:
+      - fluentd
 
   app:
     build:
@@ -43,13 +45,13 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: localhost:24224
+        fluentd-address: fluentd:24224
         tag: docker.dev-app
-        fluentd-async-connect: "true"
     env_file:
       - .env
     depends_on:
       - db
+      - fluentd
     ports:
       - "5000:5000"
     networks:
@@ -62,9 +64,8 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: localhost:24224
+        fluentd-address: fluentd:24224
         tag: docker.dev-nginx
-        fluentd-async-connect: "true"
     ports:
       - "80:80"
     volumes:
@@ -72,6 +73,7 @@ services:
     depends_on:
       - app
       - adminer
+      - fluentd
     networks:
       - devnet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       options:
         fluentd-address: localhost:24224
         tag: docker.dev-db
+        fluentd-async-connect: "true"
     env_file:
       - .env
     volumes:
@@ -27,6 +28,7 @@ services:
       options:
         fluentd-address: localhost:24224
         tag: docker.dev-adminer
+        fluentd-async-connect: "true"
     ports:
       - "8080:8080"
     networks:
@@ -43,6 +45,7 @@ services:
       options:
         fluentd-address: localhost:24224
         tag: docker.dev-app
+        fluentd-async-connect: "true"
     env_file:
       - .env
     depends_on:
@@ -61,6 +64,7 @@ services:
       options:
         fluentd-address: localhost:24224
         tag: docker.dev-nginx
+        fluentd-async-connect: "true"
     ports:
       - "80:80"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     image: postgres:13-alpine
     container_name: dev-db
     restart: unless-stopped
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: localhost:24224
+        tag: docker.dev-db
     env_file:
       - .env
     volumes:
@@ -17,6 +22,11 @@ services:
     image: adminer:latest
     container_name: dev-adminer
     restart: unless-stopped
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: localhost:24224
+        tag: docker.dev-adminer
     ports:
       - "8080:8080"
     networks:
@@ -28,6 +38,11 @@ services:
       dockerfile: Dockerfile
     container_name: dev-app
     restart: unless-stopped
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: localhost:24224
+        tag: docker.dev-app
     env_file:
       - .env
     depends_on:
@@ -41,6 +56,11 @@ services:
     image: nginx:latest
     container_name: dev-nginx
     restart: unless-stopped
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: localhost:24224
+        tag: docker.dev-nginx
     ports:
       - "80:80"
     volumes:
@@ -51,8 +71,49 @@ services:
     networks:
       - devnet
 
+  fluentd:
+    image: fluent/fluentd:v1.16-1
+    container_name: dev-fluentd
+    restart: unless-stopped
+    ports:
+      - "24224:24224"
+      - "24224:24224/udp"
+    volumes:
+      - ./fluentd/fluent.conf:/fluentd/etc/fluent.conf:ro
+    networks:
+      - devnet
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    container_name: dev-elasticsearch
+    restart: unless-stopped
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - devnet
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.11.1
+    container_name: dev-kibana
+    restart: unless-stopped
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - devnet
+
 volumes:
   db-data:
+  esdata:
 
 networks:
   devnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: fluentd:24224
+        fluentd-address: localhost:24224
+        fluentd-async-connect: "true"
         tag: docker.dev-db
     env_file:
       - .env
@@ -27,7 +28,8 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: fluentd:24224
+        fluentd-address: localhost:24224
+        fluentd-async-connect: "true"
         tag: docker.dev-adminer
     ports:
       - "8080:8080"
@@ -45,7 +47,8 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: fluentd:24224
+        fluentd-address: localhost:24224
+        fluentd-async-connect: "true"
         tag: docker.dev-app
     env_file:
       - .env
@@ -64,7 +67,8 @@ services:
     logging:
       driver: "fluentd"
       options:
-        fluentd-address: fluentd:24224
+        fluentd-address: localhost:24224
+        fluentd-async-connect: "true"
         tag: docker.dev-nginx
     ports:
       - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,10 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
-      networks:
-        - devnet
-      depends_on:
-        - fluentd
+    networks:
+      - devnet
+    depends_on:
+      - fluentd
 
   adminer:
     image: adminer:latest

--- a/fluentd/fluent.conf
+++ b/fluentd/fluent.conf
@@ -1,0 +1,15 @@
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+<match **>
+  @type elasticsearch
+  host elasticsearch
+  port 9200
+  logstash_format true
+  include_tag_key true
+  logstash_prefix docker
+  flush_interval 5s
+</match>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask==2.2.5
 Werkzeug<3.0
 psycopg2-binary==2.9.7
+
+pytest==7.4.0


### PR DESCRIPTION
## Summary
- introduce Elasticsearch and Kibana alongside Fluentd
- configure Fluentd to forward logs to Elasticsearch
- update docker-compose to run the full EFK stack
- document Kibana in the README and update quick start steps

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68450eea878083218815ed5afd57d022