### PR TITLE
Ensure fluentd starts before other containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    depends_on:
+      - fluentd
     networks:
       - devnet
 
@@ -29,6 +31,8 @@ services:
         tag: docker.dev-adminer
     ports:
       - "8080:8080"
+    depends_on:
+      - fluentd
     networks:
       - devnet
 
@@ -46,6 +50,7 @@ services:
     env_file:
       - .env
     depends_on:
+      - fluentd
       - db
     ports:
       - "5000:5000"
@@ -66,6 +71,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
+      - fluentd
       - app
       - adminer
     networks:
@@ -95,6 +101,8 @@ services:
       - "9200:9200"
     volumes:
       - esdata:/usr/share/elasticsearch/data
+    depends_on:
+      - fluentd
     networks:
       - devnet
 
@@ -107,6 +115,7 @@ services:
     ports:
       - "5601:5601"
     depends_on:
+      - fluentd
       - elasticsearch
     networks:
       - devnet


### PR DESCRIPTION
## Summary
- add `depends_on: fluentd` to all services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68451cf051108321937ba18beb2cbda5